### PR TITLE
chore: Split GitHub actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,4 +18,4 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: release-builds
-          path: release-builds
+          path: release-builds/*.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+on:
+  push:
+  pull-request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install wine
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wine64
+          sudo apt-get install -y fakeroot
+      - name: Install dependencies
+        run: npm install
+      - name: Run build
+        run: npm run build
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: release-builds
+          path: release-builds

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Run build
         run: npm run build
       - name: Upload artifacts
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: release-builds
           path: release-builds/*.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,4 @@
-on:
-  push:
-  pull-request:
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,25 +1,16 @@
-name: build
-
 on:
   push:
+    branches:
+      - master
+    tags:
+      - v*
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Install wine
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y wine64
-          sudo apt-get install -y fakeroot
-      - name: Install dependencies
-        run: npm install
-      - name: Run build
-        run: npm run build
       - name: Create release
         id: create_release
-        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -28,8 +19,11 @@ jobs:
           release_name: ${{ github.ref }}
           draft: false
           prerelease: false
+      - name: Download artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: release-builds
       - name: Upload Release Assets
-        if: startsWith(github.ref, 'refs/tags/')
         uses: csexton/release-asset-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           draft: false
           prerelease: false
       - name: Download artifacts
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v2
         with:
           name: release-builds
       - name: Upload Release Assets

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    needs: build
     steps:
       - name: Create release
         id: create_release


### PR DESCRIPTION
Split GitHub actions in `build` and `release`