### PR TITLE
fix(ci): downgrade Node to 22 LTS and smoke-test npm version in CI

### DIFF
--- a/.github/workflows/cd-upload.yml
+++ b/.github/workflows/cd-upload.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 22
       - name: Get node version
         id: node
         run: echo "::set-output name=version::$(node -v)"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 22
       - name: Get node version
         id: node
         run: echo "::set-output name=version::$(node -v)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 22
       - name: Get node version
         id: node
         run: echo "::set-output name=version::$(node -v)"
@@ -45,6 +45,11 @@ jobs:
         run: yarn electron-builder --linux --win --publish never
       - name: List release files
         run: ls -al release-builds
+      - name: Smoke-test npm version
+        # semantic-release --dry-run skips the prepare step, so it never calls
+        # `npm version`. This step replicates that exact call to catch breakage
+        # (e.g. "Yallist is not a constructor" on npm v11) before it reaches cd.yml.
+        run: npm version --no-git-tag-version --allow-same-version
       - name: Release (dry-run)
         run: yarn release --dry-run
         env:


### PR DESCRIPTION
## Summary

- Downgrades `node-version` from `24` → `22` (current LTS) in all three workflow files (`cd.yml`, `cd-upload.yml`, `ci.yml`) — Node 24 ships with npm v11, which has a regression (`Yallist is not a constructor`) that crashes `npm version`, breaking semantic-release's prepare step
- Adds an explicit `npm version --no-git-tag-version --allow-same-version` smoke-test step to `ci.yml` so any future Node upgrade that breaks npm internals fails on the PR, not silently on the release run

## Why the dry-run didn't catch it

`semantic-release --dry-run` skips all write plugins, including `prepare` — which is where `@semantic-release/npm` calls `npm version`. So the crash was completely invisible in CI until the actual release ran.

## Test plan

- [ ] CI build passes on this PR (confirming Node 22 + npm version smoke-test both green)
- [ ] Release workflow succeeds after merge