### PR TITLE
fix(ci): pin npm to v9 and fix broken smoke-test

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,6 +25,8 @@ jobs:
           key: ${{ runner.os }}-node_modules-${{ hashFiles('**/yarn.lock') }}-${{ steps.node.outputs.version }}
       - name: Install dependencies
         run: yarn install
+      - name: Pin npm to v9
+        run: npm install -g npm@9
       - name: Release
         run: yarn release
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,11 +45,13 @@ jobs:
         run: yarn electron-builder --linux --win --publish never
       - name: List release files
         run: ls -al release-builds
+      - name: Pin npm to v9
+        run: npm install -g npm@9
       - name: Smoke-test npm version
         # semantic-release --dry-run skips the prepare step, so it never calls
-        # `npm version`. This step replicates that exact call to catch breakage
-        # (e.g. "Yallist is not a constructor" on npm v11) before it reaches cd.yml.
-        run: npm version --no-git-tag-version --allow-same-version
+        # `npm version <version>`. This replicates that exact call (with a real
+        # version number) so a broken npm surfaces here, not in cd.yml.
+        run: npm version $(node -p "require('./package.json').version") --no-git-tag-version --allow-same-version
       - name: Release (dry-run)
         run: yarn release --dry-run
         env:


### PR DESCRIPTION
## What was wrong

Two bugs in the previous fix:

**1. The smoke-test never actually tested the failing code path.**
`npm version --no-git-tag-version --allow-same-version` with no version argument just prints the npm/node version string and exits 0. Semantic-release calls `npm version 3.12.69 --userconfig ...` — with a real version number — which is what triggers the Yallist crash. The smoke-test was completely ineffective.

**2. The Node version was a red herring.**
npm 10.x (which ships with *both* Node 22 and Node 24) has the Yallist bug. Downgrading from 24 to 22 changed nothing about the actual npm being used.

## Fix

- Pin npm to v9 in both `cd.yml` (before `yarn release`) and `ci.yml` (before the smoke-test). npm 9.x uses `lru-cache@9` + `yallist@4` (CJS), which doesn't have this issue.
- Fix the smoke-test to pass the actual package version: `npm version $(node -p "require('./package.json').version") --no-git-tag-version --allow-same-version` — so it exercises the same code path semantic-release does.

## Test plan

- [ ] CI passes (smoke-test now exercises the real code path with npm 9)
- [ ] Release workflow succeeds after merge