### PR TITLE
fix(cd): invoke electron-builder via yarn in upload workflow

### DIFF
--- a/.github/workflows/cd-upload.yml
+++ b/.github/workflows/cd-upload.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: yarn install
       - name: Create release files
-        run: yarn build && electron-builder ${{ matrix.build_flags }} --publish never
+        run: yarn build && yarn electron-builder ${{ matrix.build_flags }} --publish never
       - name: Rename artifacts (mac + win)
         if: runner.os == 'macOS'
         run: |


### PR DESCRIPTION
## Problem

The upload workflow (`cd-upload.yml`, triggered on `release: released`) failed on both matrix legs with:

```
electron-builder: command not found
Process completed with exit code 127
```

`electron-builder` was invoked **directly** in a raw `run:` step, where `node_modules/.bin` is not on `PATH`. (`yarn build` in the same line works because it goes through yarn.)

This is a latent bug from the electron-vite migration (#245) — it only surfaced now because this workflow only runs when a release is actually published, which never happened while the release job itself was broken.

## Fix

Prefix with `yarn` so the local binary resolves, matching how [ci.yml](../blob/master/.github/workflows/ci.yml#L45) already invokes it.

## Note

Once merged, the v3.12.69 release assets can be attached by re-running this workflow (or they'll be produced correctly on the next release).